### PR TITLE
fix(CI): minicom file communication working on github actions environment

### DIFF
--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -168,6 +168,8 @@ class iob_soc_opencryptolinux(iob_soc):
             contents.append(
                 f"""
 ### Launch minicom if running Linux
+# pass CI variable over ssh commands
+UFLAGS+=CI=$(CI)
 ifeq ($(shell grep -o rootfs.cpio.gz ../{cls.name}_mem.config),rootfs.cpio.gz)
 ifneq ($(wildcard minicom_linux_script.txt),)
 SCRIPT_STR:=-S minicom_linux_script.txt
@@ -175,7 +177,7 @@ SCRIPT_STR:=-S minicom_linux_script.txt
 TERM_STR:=TERM=linux-c-nc
 # Give fake stdin and stdout to minicom on CI (continuous integration), as it does not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
 # Github Actions sets CI="true" (https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
-ifdef CI
+ifneq ($(CI),)
 FAKE_STDIN_STDOUT:=> minicom2.log < /dev/zero
 else
 FAKE_STDIN_STDOUT:=

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -189,6 +189,9 @@ LOG_STR:=-C minicom_out.log $(FAKE_STDOUT) || cat minicom_out.log
 HOME_STR:=HOME=$$(pwd)
 # Always exit with code 0 (since linux is terminated with CTRL-C)
 CONSOLE_CMD += && ($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0))
+# potential better CONSOLE_CMD for github actions
+#CONSOLE_CMD += && (($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0)) & tail --pid=$$! -f /dev/null )
+#CONSOLE_CMD += && mkfifo tmp.fifo && (sleep 999 > tmp.fifo &) && ($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || rm tmp.fifo || (exit 0))
 endif
             """
             )

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -188,7 +188,8 @@ LOG_STR:=-C minicom_out.log $(FAKE_STDOUT) || cat minicom_out.log
 # Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
 HOME_STR:=HOME=$$(pwd)
 # Always exit with code 0 (since linux is terminated with CTRL-C)
-CONSOLE_CMD += && ($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0))
+#CONSOLE_CMD += && ($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0))
+CONSOLE_CMD += && (($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0)) & wait $$! )
 # potential better CONSOLE_CMD for github actions
 #CONSOLE_CMD += && (($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || (exit 0)) & tail --pid=$$! -f /dev/null )
 #CONSOLE_CMD += && mkfifo tmp.fifo && (sleep 999 > tmp.fifo &) && ($(HOME_STR) $(TERM_STR) minicom iobundle.dfl $(SCRIPT_STR) $(LOG_STR) || rm tmp.fifo || (exit 0))

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -161,9 +161,11 @@ ifneq ($(wildcard minicom_linux_script.txt),)
 SCRIPT_STR:=-S minicom_linux_script.txt
 # Set TERM variable to linux-c-nc (needed to run in non-interactive mode https://stackoverflow.com/a/49077622)
 TERM_STR:=TERM=linux-c-nc
+# Give fake stdin and stdout to minicom, as it might not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
+FAKE_STDIN_STDOUT:=> minicom2.log < /dev/zero
 endif
 # Set a capture file and print its contents (to work around minicom clearing the screen)
-LOG_STR:=-C minicom_out.log || cat minicom_out.log
+LOG_STR:=-C minicom_out.log $(FAKE_STDIN_STDOUT) || cat minicom_out.log
 # Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
 HOME_STR:=HOME=$$(pwd)
 # Always exit with code 0 (since linux is terminated with CTRL-C)

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -175,7 +175,7 @@ SCRIPT_STR:=-S minicom_linux_script.txt
 TERM_STR:=TERM=linux-c-nc
 # Give fake stdin and stdout to minicom on CI (continuous integration), as it does not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
 # Github Actions sets CI="true" (https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
-ifneq ($(CI),)
+ifdef CI
 FAKE_STDIN_STDOUT:=> minicom2.log < /dev/zero
 else
 FAKE_STDIN_STDOUT:=

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -173,8 +173,13 @@ ifneq ($(wildcard minicom_linux_script.txt),)
 SCRIPT_STR:=-S minicom_linux_script.txt
 # Set TERM variable to linux-c-nc (needed to run in non-interactive mode https://stackoverflow.com/a/49077622)
 TERM_STR:=TERM=linux-c-nc
-# Give fake stdin and stdout to minicom, as it might not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
+# Give fake stdin and stdout to minicom on CI (continuous integration), as it does not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
+# Github Actions sets CI="true" (https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
+ifneq ($(CI),)
 FAKE_STDIN_STDOUT:=> minicom2.log < /dev/zero
+else
+FAKE_STDIN_STDOUT:=
+endif
 endif
 # Set a capture file and print its contents (to work around minicom clearing the screen)
 LOG_STR:=-C minicom_out.log $(FAKE_STDIN_STDOUT) || cat minicom_out.log

--- a/iob_soc_opencryptolinux.py
+++ b/iob_soc_opencryptolinux.py
@@ -178,13 +178,13 @@ TERM_STR:=TERM=linux-c-nc
 # Give fake stdin and stdout to minicom on CI (continuous integration), as it does not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
 # Github Actions sets CI="true" (https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
 ifneq ($(CI),)
-FAKE_STDIN_STDOUT:=> minicom2.log < /dev/zero
+FAKE_STDOUT:=> minicom2.log
 else
-FAKE_STDIN_STDOUT:=
+FAKE_STDOUT:=
 endif
 endif
 # Set a capture file and print its contents (to work around minicom clearing the screen)
-LOG_STR:=-C minicom_out.log $(FAKE_STDIN_STDOUT) || cat minicom_out.log
+LOG_STR:=-C minicom_out.log $(FAKE_STDOUT) || cat minicom_out.log
 # Set HOME to current (fpga) directory (needed because minicom always reads the '.minirc.*' config file from HOME)
 HOME_STR:=HOME=$$(pwd)
 # Always exit with code 0 (since linux is terminated with CTRL-C)


### PR DESCRIPTION
- use [`CI` environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) to check if is running in Github Actions
- pass `CI` variable over ssh with `UFLAGS` (when running fpga from different `BOARD_SERVER`
- When running in Github Actions:
  - Give fake stdout to minicom on CI (continuous integration), as it does not have any available (based on https://www.linuxquestions.org/questions/linux-general-1/capuring-data-with-minicom-over-tty-interface-4175558631/#post5448734)
  - Run minicom process in background for Github Actions and wait for minicom to finish so that board_client does not finish as soon as minicom goes to background

Big credits to @arturum1 helping with minicom debugging!

* * *
- **NOTE 1**:  to replicate these types of problems in local environment run processes with:
```bash
nohup ssh -t sericaia > test2.log &
```
- **NOTE 2**: using a fake stdin for minicom, like `/dev/zero` causes problems since minicom is constantly reading 0s from stdin.